### PR TITLE
Move pretty_assertions to dev_dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,6 @@ syn = {version="1.0",features=["full", "extra-traits"]}
 quote = "1.0"
 proc-macro2 = "1.0"
 num-bigint = "0.4.3"
+
+[dev_dependencies]
 pretty_assertions = "1.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ fn bytes2(input: TokenStream2) -> TokenStream2 {
 #[cfg(test)]
 mod test {
     use crate::bytes2;
-    // use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
     use quote::quote;
     use syn::ExprArray;
 


### PR DESCRIPTION
### What
Move pretty_assertions to dev_dependencies.

### Why
It doesn't need to be a dependency since it is only used in tests.