### PR TITLE
Rename cargo-publish job to publish in workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - run: make publish-verify
 
-  cargo-publish:
+  publish:
     if: github.event_name == 'release'
     needs: [complete]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Rename cargo-publish job to publish in workflow.

### Why
For consistency with other job names.