### PR TITLE
Remove publish-verify job dependency on complete

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,6 @@ jobs:
 
   publish-verify:
     if: "github.ref_protected"
-    needs: [complete]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What
Remove publish-verify job dependency on complete.

### Why
There's no reason for it to wait.