### PR TITLE
Separate the publish workflows and use new versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  publish:
+    uses: stellar/actions/.github/workflows/rust-publish.yml@main
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  release:
-    types: [published]
 
 env:
   RUSTFLAGS: -D warnings
@@ -14,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, rust-analyzer-compat, build-and-test, docs]
+    needs: [fmt, rust-analyzer-compat, build-and-test, docs, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -53,16 +51,6 @@ jobs:
     - run: rustup update
     - run: cargo doc
 
-  publish:
-    if: github.event_name == 'release'
-    needs: [complete]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - run: rustup update
-    - run: rustup target add wasm32-unknown-unknown
-    - run: cargo install --locked --version 0.2.35 cargo-workspaces
-    - run: make publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  publish-dry-run:
+    if: startsWith(github.head_ref, 'release/')
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main


### PR DESCRIPTION
### What
Separate the publish workflows and use new versions.

### Why
